### PR TITLE
Make tooltips not accept pointer events

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -112,6 +112,7 @@ input:checked+.slider:before{
     margin-left:-60px;
     opacity:0;
     transition:opacity 0.15s;
+    pointer-events: none;
 }
 .tooltip .tooltiptext::after{
     content:"";


### PR DESCRIPTION
Before this change, when hovering over a button you could move your mouse off the button but onto the tooltip and it wouldn't close the tooltip. This would make it frustrating to click a button above the one you're hovering over, so this change makes it so the tooltip will no longer accept pointer events, so moving your cursor off the button will stop showing the tooltip, even if you move your cursor to where the tooltip was.